### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **ALPHA SOFTWARE**
 
-###_telegram.link_ is a Telegram API library for
+### _telegram.link_ is a Telegram API library for
 
 - **Hybrid Mobile Apps** (phone and tablet)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
